### PR TITLE
Create Zenquiz clone web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# zenquiz
+# Zenquiz Clone
+
+Een minimalistische webversie van de Zenquiz-game. De applicatie bestaat uit een enkele HTML-pagina met begeleidende CSS en JavaScript. Spelers beantwoorden acht willekeurige vragen over zen, mindfulness en ontspanning.
+
+## Functionaliteiten
+
+- Willekeurig geselecteerde set van 8 vragen per spelronde
+- Score bijhouden (10 punten per goed antwoord)
+- Directe feedback en uitleg na elk antwoord
+- Vooruitgangsbalk en mogelijkheid om opnieuw te starten
+- Resultaatoverzicht met persoonlijke boodschap
+
+## Uitvoering
+
+Open `index.html` in een moderne browser om te spelen. Er is geen build-stap nodig.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Zenquiz Clone</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="app">
+      <header class="header">
+        <h1>Zenquiz</h1>
+        <p class="subtitle">Test je kennis en bereik de zen-modus.</p>
+      </header>
+
+      <main class="game" aria-live="polite">
+        <section class="status-bar">
+          <div class="score" id="score">Score: 0</div>
+          <div class="progress">
+            <span id="questionIndex">Vraag 1</span>
+            <div class="progress-bar">
+              <div class="progress-bar__fill" id="progressFill"></div>
+            </div>
+          </div>
+          <button class="reset" id="resetButton" type="button">Opnieuw</button>
+        </section>
+
+        <section class="card" id="questionCard">
+          <h2 class="card__title" id="questionText">Laden...</h2>
+          <ul class="answers" id="answers"></ul>
+          <div class="feedback" id="feedback" role="alert"></div>
+          <button class="next" id="nextButton" type="button" disabled>
+            Volgende vraag
+          </button>
+        </section>
+
+        <section class="result hidden" id="resultScreen">
+          <h2>Gefeliciteerd!</h2>
+          <p id="resultMessage"></p>
+          <button class="reset" id="playAgain" type="button">Speel opnieuw</button>
+        </section>
+      </main>
+    </div>
+
+    <template id="answerTemplate">
+      <li>
+        <button type="button" class="answer-button"></button>
+      </li>
+    </template>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,274 @@
+const QUESTIONS = [
+  {
+    text: 'Welke Japanse term betekent letterlijk "zen-meditatie"?',
+    answers: [
+      { label: 'Zazen', correct: true },
+      { label: 'Satori', correct: false },
+      { label: 'Koan', correct: false },
+      { label: 'Ikigai', correct: false },
+    ],
+    explanation:
+      'Zazen is een meditatieve oefening die centraal staat in het zenboeddhisme en letterlijk "zittende meditatie" betekent.',
+  },
+  {
+    text: 'Wat is het doel van een koan in zenboeddhistische trainingen?',
+    answers: [
+      { label: 'Het ontwikkelen van logische redenering', correct: false },
+      { label: 'Het doorbreken van rationeel denken', correct: true },
+      { label: 'Het verbeteren van fysieke conditie', correct: false },
+      { label: 'Het leren van sutra\'s uit het hoofd', correct: false },
+    ],
+    explanation:
+      'Koans zijn paradoxale vragen of verhalen die bedoeld zijn om de rationele geest te overschrijden en inzicht te krijgen.',
+  },
+  {
+    text: 'Welke kleur staat symbool voor sereniteit en kalmte in veel culturen?',
+    answers: [
+      { label: 'Rood', correct: false },
+      { label: 'Blauw', correct: true },
+      { label: 'Geel', correct: false },
+      { label: 'Paars', correct: false },
+    ],
+    explanation:
+      'Blauw wordt vaak geassocieerd met rust en stabiliteit en bevordert een gevoel van kalmte.',
+  },
+  {
+    text: 'Wat betekent het begrip "mindfulness"?',
+    answers: [
+      { label: 'Volledig aanwezig zijn in het huidige moment', correct: true },
+      { label: 'Je gedachten analyseren', correct: false },
+      { label: 'Meditatie in stilte', correct: false },
+      { label: 'Concentratie op de toekomst', correct: false },
+    ],
+    explanation:
+      'Mindfulness verwijst naar een toestand van volledig bewust aanwezig zijn zonder oordeel.',
+  },
+  {
+    text: 'Welke plant wordt traditioneel in zen-tuinen gebruikt vanwege zijn symbool van flexibiliteit?',
+    answers: [
+      { label: 'Bamboe', correct: true },
+      { label: 'Lavendel', correct: false },
+      { label: 'Aloë vera', correct: false },
+      { label: 'Palm', correct: false },
+    ],
+    explanation:
+      'Bamboe staat symbool voor veerkracht en flexibiliteit, eigenschappen die in zen worden gewaardeerd.',
+  },
+  {
+    text: 'Wat is een kenmerk van een traditionele Japanse zen-tuin?',
+    answers: [
+      { label: 'Gebruik van veel bloemen', correct: false },
+      { label: 'Minimalistische compositie met stenen en grind', correct: true },
+      { label: 'Heldere neonkleuren', correct: false },
+      { label: 'Waterpartijen met fonteinen', correct: false },
+    ],
+    explanation:
+      'Zen-tuinen bestaan vaak uit zorgvuldig gerangschikte stenen, grind en minimalistische elementen om contemplatie te stimuleren.',
+  },
+  {
+    text: 'Welke ademhalingstechniek helpt stress te verlagen door de uitademing te verlengen?',
+    answers: [
+      { label: 'Box breathing', correct: false },
+      { label: '4-7-8 ademhaling', correct: true },
+      { label: 'Hyperventilatie', correct: false },
+      { label: 'Kapalabhati', correct: false },
+    ],
+    explanation:
+      'Bij de 4-7-8 ademhaling adem je vier tellen in, houd je zeven tellen vast en adem je acht tellen uit voor ontspanning.',
+  },
+  {
+    text: 'Hoeveel tijd wordt in zen aangeraden om elke dag te mediteren voor beginners?',
+    answers: [
+      { label: '2 minuten', correct: false },
+      { label: '5 tot 10 minuten', correct: true },
+      { label: '30 minuten', correct: false },
+      { label: '1 uur', correct: false },
+    ],
+    explanation:
+      'Korte sessies van 5 tot 10 minuten zijn ideaal om meditatie regelmatig vol te houden als beginner.',
+  },
+  {
+    text: 'Welke kwaliteit beschrijft het woord "equanimity" dat vaak wordt gebruikt in meditatiepraktijk?',
+    answers: [
+      { label: 'Creativiteit', correct: false },
+      { label: 'Gelijkmoedigheid', correct: true },
+      { label: 'Intelligentie', correct: false },
+      { label: 'Ambitie', correct: false },
+    ],
+    explanation:
+      'Equanimity staat voor innerlijke balans en gelijkmoedigheid, zelfs in uitdagende situaties.',
+  },
+  {
+    text: 'Welke factor helpt volgens onderzoek het meest bij het opbouwen van een duurzame meditatiegewoonte?',
+    answers: [
+      { label: 'Dure accessoires kopen', correct: false },
+      { label: 'Consistente dagelijkse routine', correct: true },
+      { label: 'Langdurige retraites volgen', correct: false },
+      { label: 'Meditatie-apps wisselen', correct: false },
+    ],
+    explanation:
+      'Een vaste dagelijkse routine zorgt voor automatisering en maakt het eenvoudiger om meditatie vol te houden.',
+  },
+];
+
+const appState = {
+  currentQuestionIndex: 0,
+  score: 0,
+  answered: false,
+  shuffledQuestions: [],
+};
+
+const elements = {
+  score: document.getElementById('score'),
+  questionIndex: document.getElementById('questionIndex'),
+  progressFill: document.getElementById('progressFill'),
+  answers: document.getElementById('answers'),
+  questionText: document.getElementById('questionText'),
+  feedback: document.getElementById('feedback'),
+  nextButton: document.getElementById('nextButton'),
+  resetButton: document.getElementById('resetButton'),
+  questionCard: document.getElementById('questionCard'),
+  resultScreen: document.getElementById('resultScreen'),
+  resultMessage: document.getElementById('resultMessage'),
+  playAgain: document.getElementById('playAgain'),
+  answerTemplate: document.getElementById('answerTemplate'),
+};
+
+const totalQuestions = () => appState.shuffledQuestions.length;
+
+function shuffle(array) {
+  const arr = [...array];
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function prepareGame() {
+  appState.shuffledQuestions = shuffle(QUESTIONS).slice(0, 8);
+  appState.currentQuestionIndex = 0;
+  appState.score = 0;
+  appState.answered = false;
+  elements.resultScreen.classList.add('hidden');
+  elements.questionCard.classList.remove('hidden');
+  elements.nextButton.disabled = true;
+  elements.feedback.textContent = '';
+  elements.feedback.className = 'feedback';
+  updateScore();
+  renderQuestion();
+}
+
+function updateScore() {
+  elements.score.textContent = `Score: ${appState.score}`;
+}
+
+function renderQuestion() {
+  const question = appState.shuffledQuestions[appState.currentQuestionIndex];
+  if (!question) {
+    showResults();
+    return;
+  }
+
+  elements.questionText.textContent = question.text;
+  elements.answers.innerHTML = '';
+  const shuffledAnswers = shuffle(question.answers);
+  shuffledAnswers.forEach((answer) => {
+    const answerNode = elements.answerTemplate.content.firstElementChild.cloneNode(true);
+    const button = answerNode.querySelector('button');
+    button.textContent = answer.label;
+    button.addEventListener('click', () => handleAnswer(button, answer.correct));
+    elements.answers.appendChild(answerNode);
+  });
+
+  appState.answered = false;
+  elements.nextButton.disabled = true;
+  elements.feedback.textContent = '';
+  elements.feedback.className = 'feedback';
+  updateProgress();
+}
+
+function handleAnswer(button, isCorrect) {
+  if (appState.answered) return;
+  appState.answered = true;
+
+  const buttons = elements.answers.querySelectorAll('button');
+  buttons.forEach((btn) => btn.setAttribute('disabled', 'true'));
+
+  if (isCorrect) {
+    button.classList.add('correct');
+    elements.feedback.textContent = 'Goed gedaan!';
+    elements.feedback.classList.add('correct');
+    appState.score += 10;
+    updateScore();
+  } else {
+    button.classList.add('incorrect');
+    elements.feedback.textContent = 'Niet helemaal. Volgende keer beter!';
+    elements.feedback.classList.add('incorrect');
+
+    // Highlight correct answer for feedback
+    buttons.forEach((btn) => {
+      const correctAnswer = btn.textContent === getCorrectAnswer().label;
+      if (correctAnswer) {
+        btn.classList.add('correct');
+      }
+    });
+  }
+
+  elements.feedback.insertAdjacentHTML(
+    'beforeend',
+    `<p class="explanation">${
+      appState.shuffledQuestions[appState.currentQuestionIndex].explanation
+    }</p>`
+  );
+
+  elements.nextButton.disabled = false;
+}
+
+function getCorrectAnswer() {
+  const currentQuestion = appState.shuffledQuestions[appState.currentQuestionIndex];
+  return currentQuestion.answers.find((answer) => answer.correct);
+}
+
+function updateProgress() {
+  const index = appState.currentQuestionIndex + 1;
+  elements.questionIndex.textContent = `Vraag ${index} van ${totalQuestions()}`;
+  const progressPercentage = Math.round((index / totalQuestions()) * 100);
+  elements.progressFill.style.width = `${progressPercentage}%`;
+}
+
+function goToNextQuestion() {
+  if (!appState.answered) return;
+  appState.currentQuestionIndex += 1;
+
+  if (appState.currentQuestionIndex >= totalQuestions()) {
+    showResults();
+    return;
+  }
+
+  renderQuestion();
+}
+
+function showResults() {
+  elements.questionCard.classList.add('hidden');
+  elements.resultScreen.classList.remove('hidden');
+  const maxScore = totalQuestions() * 10;
+  const percentage = Math.round((appState.score / maxScore) * 100);
+
+  let message = `Je behaalde ${appState.score} van de ${maxScore} punten (${percentage}%).`;
+  if (percentage === 100) {
+    message += ' Perfecte zen-meester!';
+  } else if (percentage >= 70) {
+    message += ' Je bent goed op weg naar innerlijke rust.';
+  } else {
+    message += ' Blijf oefenen voor nog meer zen!';
+  }
+
+  elements.resultMessage.textContent = message;
+}
+
+elements.nextButton.addEventListener('click', goToNextQuestion);
+elements.resetButton.addEventListener('click', prepareGame);
+elements.playAgain.addEventListener('click', prepareGame);
+
+document.addEventListener('DOMContentLoaded', prepareGame);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,244 @@
+:root {
+  color-scheme: light dark;
+  --primary: #4c6ef5;
+  --primary-dark: #364fc7;
+  --accent: #20c997;
+  --bg: #0f172a;
+  --bg-light: #f8fafc;
+  --text: #111827;
+  --text-light: #e2e8f0;
+  --card-bg: rgba(15, 23, 42, 0.85);
+  --card-light: rgba(255, 255, 255, 0.88);
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  background: radial-gradient(circle at top, #1d4ed8, #0f172a 65%);
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  color: var(--text-light);
+  padding: 1.5rem;
+}
+
+.app {
+  width: min(960px, 100%);
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.header h1 {
+  font-size: clamp(2.8rem, 5vw, 3.6rem);
+  letter-spacing: -0.02em;
+  font-weight: 700;
+}
+
+.subtitle {
+  margin-top: 0.75rem;
+  font-size: 1.05rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.game {
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.85), rgba(14, 116, 144, 0.7));
+  border-radius: 28px;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(14px);
+}
+
+.status-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1.75rem;
+}
+
+.score {
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.progress {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.progress span {
+  font-size: 0.95rem;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar__fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent), var(--primary));
+  transition: width 250ms ease-in-out;
+}
+
+.reset,
+.next {
+  justify-self: flex-end;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: var(--text-light);
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.reset:hover,
+.next:hover,
+.answer-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
+}
+
+.reset:focus-visible,
+.next:focus-visible,
+.answer-button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 3px;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 4vw, 2rem);
+  display: grid;
+  gap: 1.5rem;
+  position: relative;
+}
+
+.card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 24px;
+  padding: 1px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.2), rgba(20, 184, 166, 0.4));
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+.card__title {
+  font-size: clamp(1.35rem, 3vw, 1.7rem);
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.answers {
+  list-style: none;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.answer-button {
+  width: 100%;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid transparent;
+  color: inherit;
+  padding: 0.9rem 1.2rem;
+  border-radius: 16px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: border-color 180ms ease, background 180ms ease, transform 180ms ease;
+}
+
+.answer-button.correct {
+  border-color: rgba(34, 197, 94, 0.8);
+  background: rgba(34, 197, 94, 0.16);
+}
+
+.answer-button.incorrect {
+  border-color: rgba(239, 68, 68, 0.8);
+  background: rgba(239, 68, 68, 0.18);
+}
+
+.answer-button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.feedback {
+  min-height: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.feedback.correct {
+  color: #22c55e;
+}
+
+.feedback.incorrect {
+  color: #f87171;
+}
+
+.feedback .explanation {
+  margin-top: 0.75rem;
+  font-weight: 400;
+  color: rgba(226, 232, 240, 0.85);
+  line-height: 1.5;
+}
+
+.next:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.result {
+  margin-top: 2rem;
+  text-align: center;
+  display: grid;
+  gap: 1rem;
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 22px;
+  padding: 1.75rem;
+}
+
+.result p {
+  font-size: 1.05rem;
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem;
+  }
+
+  .game {
+    padding: 1.25rem;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add static HTML layout for the Zenquiz clone
- style the experience with a glassmorphism-inspired theme
- implement quiz gameplay logic with scoring, progress, and explanations

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e23919f96c8330bb5ac6024a1881ff